### PR TITLE
Feat/7 게시글 삭제

### DIFF
--- a/src/main/java/com/wanted/boardAPI/domain/post/controller/PostController.java
+++ b/src/main/java/com/wanted/boardAPI/domain/post/controller/PostController.java
@@ -57,4 +57,12 @@ public class PostController {
         return ResponseEntity.ok(postService.edit(user.getUsername(), postId, editPostRequest));
     }
 
+
+    @DeleteMapping("{postId}")
+    public ResponseEntity<Void> edit(
+            @AuthenticationPrincipal User user,
+            @PathVariable Long postId) {
+        postService.delete(user.getUsername(), postId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/wanted/boardAPI/domain/post/service/PostService.java
+++ b/src/main/java/com/wanted/boardAPI/domain/post/service/PostService.java
@@ -52,10 +52,20 @@ public class PostService {
         Post post = findById(postId);
 
         if(!haveAccessPermission(post, email))
-            throw new IllegalArgumentException("해당 게시글에 대한 접근 권한이 없습니다.");
+            throw new IllegalArgumentException("해당 게시글에 대한 수정 권한이 없습니다.");
 
         post.update(editPostRequest);
         return PostResponse.of(post);
+    }
+
+    @Transactional
+    public void delete(String email, Long postId) {
+        Post post = findById(postId);
+
+        if(!haveAccessPermission(post, email))
+            throw new IllegalArgumentException("해당 게시글에 대한 삭제 권한이 없습니다.");
+
+        postRepository.delete(post);
     }
 
     private boolean haveAccessPermission(Post post, String email){

--- a/src/test/java/com/wanted/boardAPI/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/wanted/boardAPI/domain/post/controller/PostControllerTest.java
@@ -201,4 +201,30 @@ class PostControllerTest {
 
         verify(postService).edit(eq("abcd@1234"), eq(1L), any(EditPostRequest.class));
     }
+
+    @Test
+    @DisplayName("게시글 삭제 요청")
+    @WithMockUser(username = "abcd@1234")
+    void delete() throws Exception {
+        // given
+        Member member = memberRepository.save(Member.builder() //"abcd@1234 계정으로 찾은 member
+                .email("abcd@1234")
+                .password("12345678")
+                .build());
+        EditPostRequest request = EditPostRequest.builder()
+                .title("수정한 제목")
+                .content("수정한 내용")
+                .build();
+
+        //데이터 생성
+        Post post = postRepository.save(Post.of(member, new CreatePostRequest("제목1", "내용1")));
+
+        // when
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders.delete("/api/posts/1")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isNoContent());
+
+        verify(postService).delete(eq("abcd@1234"), eq(1L));
+    }
 }

--- a/src/test/java/com/wanted/boardAPI/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/wanted/boardAPI/domain/post/service/PostServiceTest.java
@@ -126,14 +126,14 @@ class PostServiceTest {
 
         //then
         log.debug("errorMessage : {}", e.getMessage());
-        Assertions.assertThat(e.getMessage()).isEqualTo("해당 게시글에 대한 접근 권한이 없습니다.");
+        Assertions.assertThat(e.getMessage()).isEqualTo("해당 게시글에 대한 수정 권한이 없습니다.");
     }
 
     @Test
     @DisplayName("edit(게시글 수정) 성공")
     void edit2() throws Exception {
         //given
-        Member member1 = Member.builder() //"abcd@1234 계정으로 찾은 member
+        Member member1 = Member.builder()
                 .email("abcd@1234")
                 .password("12345678")
                 .build();
@@ -154,5 +154,53 @@ class PostServiceTest {
         Assertions.assertThat(post.getTitle()).isEqualTo("새로운 제목");
         Assertions.assertThat(response.getContent()).isEqualTo("새로운 내용");
         Assertions.assertThat(response.getTitle()).isEqualTo("새로운 제목");
+    }
+
+    @Test
+    @DisplayName("delete(게시글 삭제) 실패 - 작성자 본인이 아닌 경우")
+    void delete1() throws Exception {
+        //given
+        Member member1 = Member.builder()
+                .email("abcd@1234")
+                .password("12345678")
+                .build();
+        Member member2 = Member.builder()
+                .email("defg@5678")
+                .password("12345678")
+                .build();
+        Post post = Post.of(member2, new CreatePostRequest("기존 제목", "기존 내용"));
+
+        given(postRepository.findById(anyLong())).willReturn(Optional.of(post));
+
+        //when
+        Long postId = 1L;
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+            postService.delete(member1.getEmail(), postId);
+        });
+
+        //then
+        log.debug("errorMessage : {}", e.getMessage());
+        Assertions.assertThat(e.getMessage()).isEqualTo("해당 게시글에 대한 삭제 권한이 없습니다.");
+    }
+
+    @Test
+    @DisplayName("delete(게시글 삭제) 성공")
+    void delete2() throws Exception {
+        //given
+        Member member1 = Member.builder() //"abcd@1234 계정으로 찾은 member
+                .email("abcd@1234")
+                .password("12345678")
+                .build();
+
+        Post post = Post.of(member1, new CreatePostRequest("기존 제목", "기존 내용"));
+
+        given(postRepository.findById(anyLong())).willReturn(Optional.of(post));
+
+        //when
+        Long postId = 1L;
+        postService.delete(member1.getEmail(), postId);
+
+        //then
+        verify(postRepository).delete(any(Post.class));
     }
 }


### PR DESCRIPTION
## 과제 7. 특정 게시글을 삭제하는 엔드포인트
- 게시글의 ID를 받아 해당 게시글을 삭제하는 엔드포인트를 구현
- 유효성 검사 - 게시글 작성자 본인만 삭제 가능